### PR TITLE
adding support for gnome-shell 40 and 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,9 @@
   "name": "Simple monitor",
   "settings-schema": "org.gnome.shell.extensions.smonitor",
   "shell-version": [
-    "3.38"
+    "3.38",
+    "40",
+    "41"
   ],
   "url": "",
   "uuid": "simple-monitor@fcaballerop.github.io",

--- a/prefs.js
+++ b/prefs.js
@@ -8,6 +8,10 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
 const _ = Gettext.gettext;
 
+const Config = imports.misc.config;
+const [major] = Config.PACKAGE_VERSION.split('.');
+const shellVersion = Number.parseInt(major);
+
 const modelColumn = {
     label: 0,
     separator: 1
@@ -56,6 +60,8 @@ var MonitorPrefs = new GObject.registerClass(class SimpleMonitorPrefs extends Gt
 
 function buildPrefsWidget() {
     let w = new MonitorPrefs();
-    w.show_all();
+    if (shellVersion < 40) {
+        w.show_all();
+    }
     return w;
 }


### PR DESCRIPTION
adding support for gnome-shell >= 40
there is no need to call show_all() according to 
https://gjs.guide/extensions/upgrading/gnome-shell-40.html#show-all-and-destroy