### PR TITLE
use (total - available) instead of used

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -210,12 +210,13 @@ class Indicator extends PanelMenu.Button {
             let lines = result.split("\n");
             let freeSpl = lines[1].split(/[ ]+/);
             let lblStr = '';
+            let memUsed = freeSpl[1] - freeSpl[6];
             if (_settings.get_boolean('mem-perc')) {
-                let percmem = parseFloat(freeSpl[2])*100.0/parseFloat(freeSpl[1]);
+                let percmem = parseFloat(memUsed)*100.0/parseFloat(freeSpl[1]);
                 lblStr = ('  '+percmem.toFixed(1)+'%').slice(-6);
             }
             else {
-                lblStr = ('  ' + (parseFloat(freeSpl[2])/2**20).toFixed(1) + '/' + (parseFloat(freeSpl[1])/2**20).toFixed(0) + 'Gb').slice(-10);
+                lblStr = ('  ' + (parseFloat(memUsed)/2**20).toFixed(1) + '/' + (parseFloat(freeSpl[1])/2**20).toFixed(0) + 'Gb').slice(-10);
             }
             memPanelLabel.set_text(lblStr);
             });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61816972/153174018-97c24846-ac24-435d-b9a6-376bd9b043fb.png)
if we look at the image, the used memory should be around 9GB (16.2 - 6.7) not 7.6GB. 